### PR TITLE
Implement type promotion in ufunc operations (#8)

### DIFF
--- a/raptors-core/src/operations/arithmetic.rs
+++ b/raptors-core/src/operations/arithmetic.rs
@@ -5,7 +5,7 @@
 use crate::array::{Array, ArrayError};
 use crate::broadcasting::broadcast_shapes;
 use crate::types::NpyType;
-use crate::conversion::promote_dtypes;
+use crate::conversion::{promote_dtypes, convert_array, ConversionError};
 use crate::ufunc::{create_add_ufunc, create_subtract_ufunc, create_multiply_ufunc, create_divide_ufunc, create_ufunc_loop};
 
 /// Add two arrays
@@ -21,12 +21,33 @@ pub fn add(a1: &Array, a2: &Array) -> Result<Array, ArrayError> {
     let output_dtype = promote_dtypes(a1.dtype(), a2.dtype())
         .map_err(|_| ArrayError::TypeMismatch)?;
     
+    // Convert inputs to promoted type if needed
+    let a1_converted = if a1.dtype().type_() != output_dtype.type_() {
+        convert_array(a1, output_dtype.clone())
+            .map_err(|e| match e {
+                ConversionError::ArrayError(ae) => ae,
+                ConversionError::UnsupportedConversion => ArrayError::TypeMismatch,
+            })?
+    } else {
+        a1.copy()
+    };
+    
+    let a2_converted = if a2.dtype().type_() != output_dtype.type_() {
+        convert_array(a2, output_dtype.clone())
+            .map_err(|e| match e {
+                ConversionError::ArrayError(ae) => ae,
+                ConversionError::UnsupportedConversion => ArrayError::TypeMismatch,
+            })?
+    } else {
+        a2.copy()
+    };
+    
     // Create output array
     let mut output = Array::new(broadcast_shape, output_dtype)?;
     
     // Use ufunc system for broadcasting support
     let add_ufunc = create_add_ufunc();
-    let inputs = vec![a1, a2];
+    let inputs = vec![&a1_converted, &a2_converted];
     
     // Try using ufunc system first (handles broadcasting)
     if let Ok(()) = create_ufunc_loop(&add_ufunc, &inputs, &mut output) {
@@ -66,12 +87,33 @@ pub fn subtract(a1: &Array, a2: &Array) -> Result<Array, ArrayError> {
     let output_dtype = promote_dtypes(a1.dtype(), a2.dtype())
         .map_err(|_| ArrayError::TypeMismatch)?;
     
+    // Convert inputs to promoted type if needed
+    let a1_converted = if a1.dtype().type_() != output_dtype.type_() {
+        convert_array(a1, output_dtype.clone())
+            .map_err(|e| match e {
+                ConversionError::ArrayError(ae) => ae,
+                ConversionError::UnsupportedConversion => ArrayError::TypeMismatch,
+            })?
+    } else {
+        a1.copy()
+    };
+    
+    let a2_converted = if a2.dtype().type_() != output_dtype.type_() {
+        convert_array(a2, output_dtype.clone())
+            .map_err(|e| match e {
+                ConversionError::ArrayError(ae) => ae,
+                ConversionError::UnsupportedConversion => ArrayError::TypeMismatch,
+            })?
+    } else {
+        a2.copy()
+    };
+    
     // Create output array
     let mut output = Array::new(broadcast_shape, output_dtype)?;
     
     // Use ufunc system for broadcasting support
     let subtract_ufunc = create_subtract_ufunc();
-    let inputs = vec![a1, a2];
+    let inputs = vec![&a1_converted, &a2_converted];
     
     // Try using ufunc system first (handles broadcasting)
     if let Ok(()) = create_ufunc_loop(&subtract_ufunc, &inputs, &mut output) {
@@ -111,12 +153,33 @@ pub fn multiply(a1: &Array, a2: &Array) -> Result<Array, ArrayError> {
     let output_dtype = promote_dtypes(a1.dtype(), a2.dtype())
         .map_err(|_| ArrayError::TypeMismatch)?;
     
+    // Convert inputs to promoted type if needed
+    let a1_converted = if a1.dtype().type_() != output_dtype.type_() {
+        convert_array(a1, output_dtype.clone())
+            .map_err(|e| match e {
+                ConversionError::ArrayError(ae) => ae,
+                ConversionError::UnsupportedConversion => ArrayError::TypeMismatch,
+            })?
+    } else {
+        a1.copy()
+    };
+    
+    let a2_converted = if a2.dtype().type_() != output_dtype.type_() {
+        convert_array(a2, output_dtype.clone())
+            .map_err(|e| match e {
+                ConversionError::ArrayError(ae) => ae,
+                ConversionError::UnsupportedConversion => ArrayError::TypeMismatch,
+            })?
+    } else {
+        a2.copy()
+    };
+    
     // Create output array
     let mut output = Array::new(broadcast_shape, output_dtype)?;
     
     // Use ufunc system for broadcasting support
     let multiply_ufunc = create_multiply_ufunc();
-    let inputs = vec![a1, a2];
+    let inputs = vec![&a1_converted, &a2_converted];
     
     // Try using ufunc system first (handles broadcasting)
     if let Ok(()) = create_ufunc_loop(&multiply_ufunc, &inputs, &mut output) {
@@ -156,12 +219,33 @@ pub fn divide(a1: &Array, a2: &Array) -> Result<Array, ArrayError> {
     let output_dtype = promote_dtypes(a1.dtype(), a2.dtype())
         .map_err(|_| ArrayError::TypeMismatch)?;
     
+    // Convert inputs to promoted type if needed
+    let a1_converted = if a1.dtype().type_() != output_dtype.type_() {
+        convert_array(a1, output_dtype.clone())
+            .map_err(|e| match e {
+                ConversionError::ArrayError(ae) => ae,
+                ConversionError::UnsupportedConversion => ArrayError::TypeMismatch,
+            })?
+    } else {
+        a1.copy()
+    };
+    
+    let a2_converted = if a2.dtype().type_() != output_dtype.type_() {
+        convert_array(a2, output_dtype.clone())
+            .map_err(|e| match e {
+                ConversionError::ArrayError(ae) => ae,
+                ConversionError::UnsupportedConversion => ArrayError::TypeMismatch,
+            })?
+    } else {
+        a2.copy()
+    };
+    
     // Create output array
     let mut output = Array::new(broadcast_shape, output_dtype)?;
     
     // Use ufunc system for broadcasting support
     let divide_ufunc = create_divide_ufunc();
-    let inputs = vec![a1, a2];
+    let inputs = vec![&a1_converted, &a2_converted];
     
     // Try using ufunc system first (handles broadcasting)
     if let Ok(()) = create_ufunc_loop(&divide_ufunc, &inputs, &mut output) {


### PR DESCRIPTION
## Summary
Implements proper type promotion in arithmetic operations when operands have different types (e.g., int + float).

## Changes
- Convert input arrays to promoted type before ufunc execution
- Apply type promotion to add, subtract, multiply, divide operations
- Uses convert_array to convert inputs when types don't match
- Ensures ufunc loops receive arrays of the same (promoted) type

## Implementation Notes
- Type promotion determines the common type using promote_dtypes()
- Input arrays are converted to the promoted type if they don't already match
- This ensures ufunc loops can find appropriate loop functions
- Maintains backward compatibility for same-type operations

## Example
```python
arr1 = raptors.array([1, 2, 3])  # int
arr2 = raptors.array([1.0, 2.0, 3.0])  # float
result = arr1 + arr2  # Now properly promotes to float
```

Fixes #8