### PR TITLE
Fix test_stack_split_inverse shape mismatch (Issue #59)

### DIFF
--- a/raptors-core/tests/numpy_port_operations_test.rs
+++ b/raptors-core/tests/numpy_port_operations_test.rs
@@ -571,8 +571,15 @@ fn test_stack_split_inverse() {
     let split_result = split(&stacked, SplitSpec::Sections(2), 0).unwrap();
     
     assert_eq!(split_result.len(), 2);
-    assert_array_equal(&split_result[0], &arr1);
-    assert_array_equal(&split_result[1], &arr2);
+    
+    // Squeeze axis 0 from each split result to get back the original shape
+    // This matches NumPy's behavior: splitting a stacked array returns arrays
+    // with an extra dimension that needs to be squeezed to reverse the stack operation
+    let squeezed1 = squeeze_axis(&split_result[0], 0).unwrap();
+    let squeezed2 = squeeze_axis(&split_result[1], 0).unwrap();
+    
+    assert_array_equal(&squeezed1, &arr1);
+    assert_array_equal(&squeezed2, &arr2);
 }
 
 // Test with helpers


### PR DESCRIPTION
## Summary

This PR fixes the `test_stack_split_inverse` test failure by adding a `squeeze_axis` helper function and updating the test to squeeze split results before comparing them to the original arrays.

## Problem

The test `test_stack_split_inverse` failed because:
- Stacking two `[2, 3]` arrays along axis 0 creates a `[2, 2, 3]` array
- Splitting this along axis 0 into 2 sections returns arrays of shape `[1, 2, 3]`
- The test expected `[2, 3]` arrays (matching the original)
- NumPy's behavior: split returns `[1, 2, 3]`, which must be squeezed along axis 0 to get `[2, 3]`

## Solution

The test expectation was incorrect. When splitting a stacked array, the result has an extra dimension that needs to be squeezed to reverse the stack operation. This matches NumPy's behavior.

## Changes

1. **Added `squeeze_axis` helper function** in `raptors-core/tests/numpy_port/helpers.rs`:
   - Creates a zero-copy view with a specific axis removed if it has size 1
   - Uses `squeeze_dims` to compute the new shape
   - Preserves the original stride pattern by removing the stride for the squeezed axis
   - Wraps the array in `Arc` to enable view creation

2. **Updated `test_stack_split_inverse`** in `raptors-core/tests/numpy_port_operations_test.rs`:
   - Squeezes each split result along axis 0 before comparing to the original arrays
   - Matches NumPy's behavior: `np.squeeze(split_result, axis=0)`

## Testing

- ✅ `test_stack_split_inverse` now passes
- ✅ All other tests in the file still pass (no regressions)
- ✅ Matches NumPy's behavior for stack/split inverse operations

## Related Issues

Fixes #59